### PR TITLE
fixed typo

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function mydb(opts){
     throw new Error('Missing `url` (mydb server) option.');
   }
 
-  if ('string' == url) {
+  if (typeof url == 'string') {
     var _url = url;
     url = function(){
       return _url;


### PR DESCRIPTION
Should wrap `url` option in a function if the type, not value is `'string'`.
