### PR TITLE
Handle case where session field is replaced on request

### DIFF
--- a/session.js
+++ b/session.js
@@ -120,6 +120,11 @@ Session.prototype.regenerate = function(fn){
   debug('regenerating');
   this.$req.originalSession.regenerate(function(err){
     if (err) return fn(err);
+    if (self !== self.$req.session) {
+      // req.session has been replaced, restore it
+      self.$req.originalSession = self.$req.session;
+      self.$req.session = self;
+    }
     self.reload(fn);
   });
   return this;


### PR DESCRIPTION
This pull request fixes an issue where the `session` field of the `req` object would get replaced by a "regular" connect session after the call to `originalSession.regenerate()`.

We check if the session has been replaced to avoid breaking compatibility with versions of connect which might not do this replacement. If it has indeed been replaced we restore the special mydb session on the `session` field, and put the newly created session on the `originalSession` field.