### PR TITLE
Copy reference to new cookie object

### DIFF
--- a/session.js
+++ b/session.js
@@ -125,6 +125,8 @@ Session.prototype.regenerate = function(fn){
       self.$req.originalSession = self.$req.session;
       self.$req.session = self;
     }
+    // make sure the reference to the new cookie object is copied over
+    self.cookie = self.$req.originalSession.cookie;
     self.reload(fn);
   });
   return this;


### PR DESCRIPTION
Previously we were holding onto the old `cookie` reference.